### PR TITLE
Add support for Kommo

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ try {
 
   const token = JSON.parse(readFileSync("./token.json", "utf-8"));
 
-  const amo = new Amo("mydomain", { ...auth, ...token }, {
+  const amo = new Amo("mydomain.amocrm.ru", { ...auth, ...token }, {
     on_token: (new_token) => {
       console.log("New token obtained", new_token);
       writeFileSync("./token.json", JSON.stringify(new_token, null, 2), "utf8");
@@ -116,12 +116,12 @@ try {
 
 To create a client instance, you should provide 2 or 3 args to the constructor:
 
-- subdomain
+- API domain
 - auth data (may be different)
 - options (optionally)
 
 ```ts
-const amo = new Amo("subdomain", auth_object, options_object);
+const amo = new Amo("mydomain.amocrm.ru", auth_object, options_object);
 ```
 
 ### Options
@@ -144,7 +144,7 @@ expiration.
 Usually, this method is used just once while a fresh app is registered. You provide the code and get the token data.
 
 ```ts
-const amo = new Amo("mydomain", {
+const amo = new Amo("mydomain.amocrm.ru", {
     client_id: "1111-2222-3333",
     client_secret: "myclientsecret",
     grant_type: "authorization_code",
@@ -162,7 +162,7 @@ This method is used every time after the first authorization by code. The API do
 `expires_at`, but lib returns it in `on_token` callback value.
 
 ```ts
-const amo = new Amo("mydomain", {
+const amo = new Amo("mydomain.amocrm.ru", {
     client_id: "1111-2222-3333",
     client_secret: "myclientsecret",
     redirect_uri: "https://myredirect.org",
@@ -250,7 +250,7 @@ Webhook handling example. Remember that `webhookHandler()` is a function factory
 it.
 
 ```ts
-const amo = new Amo("subdomain", auth_object, options_object);
+const amo = new Amo("mydomain.amocrm.ru", auth_object, options_object);
 
 amo.on("leads:status", (lead) => console.log(lead.id));
 
@@ -276,7 +276,7 @@ Handling is simple:
 
 ```ts
 try {
-  const amo = new Amo("subdomain", auth_object, options_object);
+  const amo = new Amo("mydomain.amocrm.ru", auth_object, options_object);
   const lead = amo.lead.getLeadById(6969);
 } catch (err) {
   if (err instanceof AuthError) {

--- a/examples/account-info.deno.ts
+++ b/examples/account-info.deno.ts
@@ -9,7 +9,7 @@ try {
 
   const token = JSON.parse(Deno.readTextFileSync("./token.json"));
 
-  const amo = new Amo("mydomain", { ...auth, ...token }, {
+  const amo = new Amo("mydomain.amocrm.ru", { ...auth, ...token }, {
     on_token: (new_token) => {
       console.log("New token obtained", new_token);
       Deno.writeTextFileSync("./token.json", JSON.stringify(new_token, null, 2));

--- a/examples/account-info.node.ts
+++ b/examples/account-info.node.ts
@@ -10,7 +10,7 @@ try {
 
   const token = JSON.parse(readFileSync("./token.json", "utf-8"));
 
-  const amo = new Amo("mydomain", { ...auth, ...token }, {
+  const amo = new Amo("mydomain.amocrm.ru", { ...auth, ...token }, {
     on_token: (new_token) => {
       console.log("New token obtained", new_token);
       writeFileSync("./token.json", JSON.stringify(new_token, null, 2), "utf8");

--- a/examples/lead.deno.ts
+++ b/examples/lead.deno.ts
@@ -9,7 +9,7 @@ try {
 
   const token = JSON.parse(Deno.readTextFileSync("./token.json"));
 
-  const amo = new Amo("mydomain", { ...auth, ...token }, {
+  const amo = new Amo("mydomain.amocrm.ru", { ...auth, ...token }, {
     on_token: (new_token) => {
       console.log("New token obtained", new_token);
       Deno.writeTextFileSync("./token.json", JSON.stringify(new_token, null, 2));

--- a/examples/lead.node.ts
+++ b/examples/lead.node.ts
@@ -10,7 +10,7 @@ try {
 
   const token = JSON.parse(readFileSync("./token.json", "utf-8"));
 
-  const amo = new Amo("mydomain", { ...auth, ...token }, {
+  const amo = new Amo("mydomain.amocrm.ru", { ...auth, ...token }, {
     on_token: (new_token) => {
       console.log("New token obtained", new_token);
       writeFileSync("./token.json", JSON.stringify(new_token, null, 2), "utf8");

--- a/src/amo.ts
+++ b/src/amo.ts
@@ -76,12 +76,12 @@ export class Amo extends EventEmitter<WebhookEventMap> {
   private _file?: FileApi;
 
   constructor(
-    baseUrl: string,
+    base_url: string,
     auth: OAuthCode | OAuth & Pick<OAuthRefresh, "client_id" | "client_secret" | "redirect_uri">,
     options?: Options,
   ) {
     super();
-    this.rest = new RestClient(baseUrl, auth, options);
+    this.rest = new RestClient(base_url, auth, options);
 
     this._account = new AccountApi(this.rest);
     this._lead = new LeadApi(this.rest);

--- a/src/amo.ts
+++ b/src/amo.ts
@@ -76,12 +76,12 @@ export class Amo extends EventEmitter<WebhookEventMap> {
   private _file?: FileApi;
 
   constructor(
-    subdomain: string,
+    baseUrl: string,
     auth: OAuthCode | OAuth & Pick<OAuthRefresh, "client_id" | "client_secret" | "redirect_uri">,
     options?: Options,
   ) {
     super();
-    this.rest = new RestClient(subdomain, auth, options);
+    this.rest = new RestClient(baseUrl, auth, options);
 
     this._account = new AccountApi(this.rest);
     this._lead = new LeadApi(this.rest);

--- a/src/core/rest-client.ts
+++ b/src/core/rest-client.ts
@@ -12,11 +12,11 @@ export class RestClient {
   private _token?: OAuth;
 
   constructor(
-    private subdomain: string,
+    private baseUrl: string,
     private auth: OAuthCode | OAuth & Pick<OAuthRefresh, "client_id" | "client_secret" | "redirect_uri">,
     private options?: Options,
   ) {
-    this.url_base = `https://${this.subdomain}.amocrm.ru`;
+    this.url_base = `https://${this.baseUrl}`; //subdomain.amocrm.ru || subdomain.kommo.com
     if (this.isOAuth(this.auth)) {
       this._token = {
         token_type: this.auth.token_type,

--- a/src/core/rest-client.ts
+++ b/src/core/rest-client.ts
@@ -12,11 +12,11 @@ export class RestClient {
   private _token?: OAuth;
 
   constructor(
-    private baseUrl: string,
+    private base_url: string,
     private auth: OAuthCode | OAuth & Pick<OAuthRefresh, "client_id" | "client_secret" | "redirect_uri">,
     private options?: Options,
   ) {
-    this.url_base = `https://${this.baseUrl}`; //subdomain.amocrm.ru || subdomain.kommo.com
+    this.url_base = `https://${this.base_url}`; //subdomain.amocrm.ru | subdomain.kommo.com
     if (this.isOAuth(this.auth)) {
       this._token = {
         token_type: this.auth.token_type,

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -24,7 +24,7 @@ const token = {
 
 mf.install();
 
-const amo = new Amo("mydomain", { ...auth, ...token }, {
+const amo = new Amo("mydomain.amocrm.ru", { ...auth, ...token }, {
   on_token: (new_token) => console.log("New token obtained", new_token),
 });
 
@@ -109,7 +109,7 @@ Deno.test("should return AuthError", async () => {
     return new Response(null, { status: 403 });
   });
 
-  const amo = new Amo("mydomain", { ...auth, ...token, expires_at: 0 }, {
+  const amo = new Amo("mydomain.amocrm.ru", { ...auth, ...token, expires_at: 0 }, {
     on_token: (new_token) => console.log("New token obtained", new_token),
   });
 

--- a/tests/webhook.test.ts
+++ b/tests/webhook.test.ts
@@ -45,7 +45,7 @@ const test_task = {
 };
 
 Deno.test("webhook should work properly", async () => {
-  const amo = new Amo("mydomain", { ...auth, ...token }, {
+  const amo = new Amo("mydomain.amocrm.ru", { ...auth, ...token }, {
     on_token: (new_token) => console.log("New token obtained", new_token),
   });
 


### PR DESCRIPTION
If we switch from 'subdomain' to baseUrl, we can provide full url of platform to access both Kommo and amoCRM API

Solves each of these cases:
1. ru fork on subdomain.amocrm.ru
2. en fork on subdomain.kommo.com
3. en fork on subdomain.amocrm.com (deprecated)