### PR TITLE
add page support to ResponseGetCustomFields

### DIFF
--- a/src/api/custom-fields/types.ts
+++ b/src/api/custom-fields/types.ts
@@ -1,4 +1,4 @@
-import type { DeepPartial, Links, PageCount, RequestId, Total } from "../../typings/utility.ts";
+import type { DeepPartial, Links, Page, PageCount, RequestId, Total } from "../../typings/utility.ts";
 import type { CustomFieldsValue, CustomFieldsValueGroup } from "../../typings/entities.ts";
 
 export type ResponseGetCustomFields = Total & Page & PageCount & Links & {

--- a/src/api/custom-fields/types.ts
+++ b/src/api/custom-fields/types.ts
@@ -1,7 +1,7 @@
 import type { DeepPartial, Links, PageCount, RequestId, Total } from "../../typings/utility.ts";
 import type { CustomFieldsValue, CustomFieldsValueGroup } from "../../typings/entities.ts";
 
-export type ResponseGetCustomFields = Total & PageCount & Links & {
+export type ResponseGetCustomFields = Total & Page & PageCount & Links & {
   _embedded: {
     custom_fields: ResponseGetCustomFieldById[];
   };


### PR DESCRIPTION
add page support to ResponseGetCustomFields type to show page number when requesting list of custom fields

example of amoCRM response:
```json
{
    "_total_items": 103,
    "_page": 1,
    "_page_count": 3,
    "_links": {
        "self": {
            "href": "https://test.amocrm.ru/api/v4/leads/custom_fields?page=1&limit=50"
        },
        "next": {
            "href": "https://test.amocrm.ru/api/v4/leads/custom_fields?page=2&limit=50"
        },
        "last": {
            "href": "https://test.amocrm.ru/api/v4/leads/custom_fields?page=3&limit=50"
        }
    },
    "_embedded": {
        "custom_fields": [
                      {
                "id": 2929639,
                "name": "Text field",
                "type": "text",
                "account_id": 30591685,
                "code": null,
                "sort": 568,
                "is_api_only": false,
                "enums": null,
                "group_id": "leads_16091668441111",
                "required_statuses": [],
                "is_deletable": true,
                "is_predefined": false,
                "entity_type": "leads",
                "tracking_callback": null,
                "remind": null,
                "triggers": [],
                "currency": null,
                "hidden_statuses": [],
                "chained_lists": null,
                "_links": {
                    "self": {
                        "href": "https://test.amocrm.ru/api/v4/leads/custom_fields/2929639?page=1&limit=50"
                    }
                }
            }
        ]
    }
}
```