### PR TITLE
[add]: multitext custom field literal

### DIFF
--- a/src/typings/entities.ts
+++ b/src/typings/entities.ts
@@ -522,7 +522,9 @@ export type CustomFieldsValueTypes =
   /** Денежное (платная опция Супер-поля) */
   | "monetary"
   /** Файл */
-  | "file";
+  | "file"
+  /** Мультитекст для контактов (поля с телефоном и email) */
+  | "multitext";
 
 export type CustomFieldsValueGroup = {
   /** ID группы полей */


### PR DESCRIPTION
According to amoCRM [documentation](https://www.amocrm.ru/developers/content/crm_platform/custom-fields#multitext) there is a type of such custom field as multitext, but such option in the library type is currently missing. I suggest adding this literal to the type.