### PR TITLE
Отключение ошибки на ответ 204 no content

### DIFF
--- a/src/core/rest-client.ts
+++ b/src/core/rest-client.ts
@@ -70,6 +70,7 @@ export class RestClient {
   private async checkError(res: Response, method: HttpMethod): Promise<void> {
     if (res.ok !== false && res.status !== 204) return;
     if (res.status === 204 && method === "DELETE") return;
+    if (res.status === 204 && this.options?.no_content_no_error) return;
     if (res.headers.get("Content-Type") === "application/problem+json") {
       throw new ApiError(res.body ? await res.json() : "Error", `${res.status} ${res.statusText}, ${res.url}`);
     } else if (res.status === 204) {

--- a/src/typings/lib.ts
+++ b/src/typings/lib.ts
@@ -4,6 +4,7 @@ import { JSONValue } from "./utility.ts";
 export type Options = {
   request_delay?: number;
   on_token?: (token: OAuth) => void | Promise<void>;
+  no_content_no_error?: boolean;
 };
 
 export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";


### PR DESCRIPTION
Здравствуйте.

Я интенсивно использую Вашу библиотеку. Спасибо Вам за её создание.
В процессе разработки я постоянно натыкаюсь на следующую проблему, которая мне не даёт покоя.
Я постараюсь привести некоторый пример, чтобы объяснить в чём суть.

Сразу скажу что это выдуманный пример, который нужен лишь для пояснения сути  моего PR.

У меня есть некий сервис, который реализует некоторую бизнес-логику взаимодействуя с amoCRM с использованием данной библиотеки. Мне нужно проверить, есть ли искомая сделка в amoCRM. Если есть - выполнить определённую бизнес-логику. Если нет - создать сделку и выполнить логику.

В текущей ситуации одним из возможных реализаций данного задания будет следующий код:

``` typescript
export class SomeService {
constructor(private readonly amo: AmoService) {}
  async command() {
    const phone = '74955555555';
    // find lead
    let leads = await this.getLeads(phone);
    // if lead not exist, create new lead
    if(!leads.length) {
      const response = await this.amo.lead.addLeads([{name: phone}]);
      leads = await this.getLeads(phone);
    }
    // some logic
  }
  async getLeads(query) {
    try {
      const leads = await this.amo.lead.getLeads({query});
      return leads._embedded.leads;
    } catch(e) {
      if(e instanceof NoContentError) return [];
      throw e;
    }
  }
}
```

В данном примере мы обернули функцию getLeads в функцию getLeads класса SomeService, чтобы отловить случай с выбрасыванием ошибки NoContentError через try/catch. На мой взгляд функция getLeads избыточна и создаёт дополнительный "шум" в кодовой базе. Как реализовать данную логику более лаконично я немного затрудняюсь. Возможно, я чего-то не знаю, поэтому любой Ваш комментарий будет ценен для меня.

Я предлагаю опционально отключить выбрасывание ошибки при 204 ответе сервера amoCRM, чтобы этот же код можно было написать более лаконично.

``` typescript
export class SomeService {
constructor(private readonly amo: AmoService) {}
  async command() {
    const phone = '74955555555';
    // find lead
    let leads = await this.amo.lead.getLeads({query: phone});
    // if lead not exist, create new lead
    if (!leads) {
      const response = await this.amo.lead.addLeads([{ name: phone }]);
      leads = await this.amo.lead.getLeads({query: phone});
    }
    // some logic
  }
}
```

В коде данной библиотеки я лишь добавил необязательную boolean опцию "no_content_no_error" для отключения выбрасывания ошибки NoContentError. Это должно сохранить обратную совместимость с предыдущими версиями библиотеки и, как мне кажется, улучшить опыт взаимодействия с библиотекой.

Это лишь моё предложение.
Любой ответ будет ценен для меня.
Спасибо.