### PR TITLE
Allow number and boolean in CustomFields values

### DIFF
--- a/src/typings/entities.ts
+++ b/src/typings/entities.ts
@@ -427,7 +427,7 @@ export type CustomFieldsValue = Partial<{
     /** ID значения */
     enum_id: number;
     /** Значение */
-    value: string;
+    value: string | number | boolean;
     /** Сортировка значения */
     sort: number;
     /** Символьный код значения */


### PR DESCRIPTION
date, date_time, birthday field types support unix timestamp as a value
checkbox support boolean as a value

details:
https://www.amocrm.ru/developers/content/crm_platform/custom-fields#%D0%94%D0%BE%D1%81%D1%82%D1%83%D0%BF%D0%BD%D1%8B%D0%B5-%D1%82%D0%B8%D0%BF%D1%8B-%D0%BF%D0%BE%D0%BB%D0%B5%D0%B9