### PR TITLE
fix(types): change lead external_id type to string

### DIFF
--- a/src/api/lead/types.ts
+++ b/src/api/lead/types.ts
@@ -41,7 +41,7 @@ export type RequestAddLead =
       companies?: Partial<Company>[];
       metadata?: Partial<UnsrotedMetadataForm> | Partial<UnsrotedMetadataSip>;
       source?: {
-        external_id?: number;
+        external_id?: string;
         type?: string;
       };
     };
@@ -118,7 +118,7 @@ export type RequestAddComplex =
       companies?: Partial<Company>[];
       metadata?: Partial<UnsrotedMetadataForm> | Partial<UnsrotedMetadataSip>;
       source?: {
-        external_id?: number;
+        external_id?: string;
         type?: string;
       };
     };


### PR DESCRIPTION
The [docs](https://www.amocrm.ru/developers/content/crm_platform/leads-api) have the int specified in external_id type, but trying to sent int results in validation error (expects string)

Sources external_id is string (see [docs](https://www.amocrm.ru/developers/content/crm_platform/sources-api#%D0%94%D0%BE%D0%B1%D0%B0%D0%B2%D0%BB%D0%B5%D0%BD%D0%B8%D0%B5-%D0%B8%D1%81%D1%82%D0%BE%D1%87%D0%BD%D0%B8%D0%BA%D0%BE%D0%B2))

amoCRM Chats API has the correct string type in docs for external_id :D

