### PR TITLE
Fix typo in getStatusById method

### DIFF
--- a/src/api/status/client.ts
+++ b/src/api/status/client.ts
@@ -17,7 +17,7 @@ export class StatusApi extends Endpoint {
   }
 
   /** Метод позволяет получить модель статуса покупателя в аккаунте по ID статуса. */
-  getStatuseById(id: number): Promise<ResponseGetStatusById> {
+  getStatusById(id: number): Promise<ResponseGetStatusById> {
     return this.rest.get<ResponseGetStatusById>({
       url: `/api/v4/customers/statuses/${id}`,
     });


### PR DESCRIPTION
There's a typo in StatusApi function - 

`getStatuseById` instead of `getStatusById`