### PR TITLE
Some fixes for note typings

### DIFF
--- a/src/api/note/types.ts
+++ b/src/api/note/types.ts
@@ -25,7 +25,7 @@ export type ResponseAddNotes = Links & {
 export type RequestUpdateNote = Pick<Note, "id" | "entity_id" | "note_type" | "params">;
 export type ResponseUpdateNotes = Links & {
   _embedded: {
-    notes: RequestUpdateNoteById[];
+    notes: (Links & Pick<Note, "id" | "entity_id" | "updated_at">)[];
   };
 };
 

--- a/src/api/note/types.ts
+++ b/src/api/note/types.ts
@@ -17,14 +17,14 @@ export type RequestAddNote =
   };
 
 export type ResponseAddNotes = Links & {
-  _ebmedded: {
+  _embedded: {
     notes: (Links & Pick<Note, "id" | "entity_id"> & RequestId)[];
   };
 };
 
 export type RequestUpdateNote = Pick<Note, "id" | "entity_id" | "note_type" | "params">;
 export type ResponseUpdateNotes = Links & {
-  _ebmedded: {
+  _embedded: {
     notes: RequestUpdateNoteById[];
   };
 };

--- a/src/api/note/types.ts
+++ b/src/api/note/types.ts
@@ -29,5 +29,5 @@ export type ResponseUpdateNotes = Links & {
   };
 };
 
-export type RequestUpdateNoteById = Links & Pick<Note, "id" | "entity_id" | "updated_at">;
+export type RequestUpdateNoteById = Links & Pick<Note, "entity_id" | "note_type" | "params">;
 export type ResponseUpdateNoteById = ResponseUpdateNotes;


### PR DESCRIPTION
Fixed:
- typos from "_ebmedded" to "_embedded"
- params for request when we update note by id
- response params when we update many notes